### PR TITLE
Feature/control tick escaping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
                 <artifactId>h2</artifactId>
                 <version>1.4.192</version>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>2.13.0</version>
+                <scope>test</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/spring-i18n-support/pom.xml
+++ b/spring-i18n-support/pom.xml
@@ -129,6 +129,12 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/spring-i18n-support/src/main/java/com/namics/oss/spring/support/i18n/AbstractDaoMessageSource.java
+++ b/spring-i18n-support/src/main/java/com/namics/oss/spring/support/i18n/AbstractDaoMessageSource.java
@@ -60,7 +60,7 @@ public abstract class AbstractDaoMessageSource extends AbstractMessageSource imp
 	 */
 	private boolean fallbackForUnknownLanguages;
 
-	private static final Pattern REGEX_PLACEHOLDER = Pattern.compile("\\{[0-9]+\\}");
+	protected static final Pattern REGEX_PLACEHOLDER = Pattern.compile("\\{[0-9]+\\}");
 
 	/**
 	 * {@inheritDoc}

--- a/spring-i18n-support/src/main/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSource.java
+++ b/spring-i18n-support/src/main/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSource.java
@@ -22,10 +22,20 @@ import static org.springframework.util.StringUtils.hasText;
  * @since Namics commons i18n 1.2 - Oct 14, 2010
  */
 public class NoCacheDaoMessageSource extends AbstractDaoMessageSource {
+
 	/**
 	 * Logger-Category.
 	 */
 	private static final Logger LOG = LoggerFactory.getLogger(NoCacheDaoMessageSource.class);
+
+	/**
+	 * If true, ticks get escaped by adding another tick (i.e. ' is replaced by '').
+	 * This overrides the default behaviour which escapes ticks if there is a placeholder in the resolved message (see method {@link #postProcessMessage}).
+	 *
+	 * By setting the property {@link #alwaysEscapeTicks} to true, escaping of ticks also takes place if no placeholder is present in the resolved message.
+	 */
+	private boolean alwaysEscapeTicks = false;
+
 
 	/**
 	 * {@inheritDoc}
@@ -39,7 +49,7 @@ public class NoCacheDaoMessageSource extends AbstractDaoMessageSource {
 
 				// Escape ticks even if no placeholders are present.
 				// Method getMessageForLocale does already escape ticks if placeholders exist.
-				if (hasText(messageForLocale) && messageForLocale.contains("'") && !REGEX_PLACEHOLDER.matcher(messageForLocale).find()) {
+				if (alwaysEscapeTicks && hasText(messageForLocale) && messageForLocale.contains("'") && !REGEX_PLACEHOLDER.matcher(messageForLocale).find()) {
 					messageForLocale = messageForLocale.replaceAll("'", "''");
 				}
 
@@ -68,5 +78,18 @@ public class NoCacheDaoMessageSource extends AbstractDaoMessageSource {
 	@Override
 	public void reload() throws ReloadableResourceException {
 		LOG.info("NoCacheDaoMessageSource is not reloadable");
+	}
+
+	public boolean isAlwaysEscapeTicks() {
+		return alwaysEscapeTicks;
+	}
+
+	public void setAlwaysEscapeTicks(boolean alwaysEscapeTicks) {
+		this.alwaysEscapeTicks = alwaysEscapeTicks;
+	}
+
+	public NoCacheDaoMessageSource alwaysEscapeTicks(boolean alwaysEscapeTicks) {
+		setAlwaysEscapeTicks(alwaysEscapeTicks);
+		return this;
 	}
 }

--- a/spring-i18n-support/src/main/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSource.java
+++ b/spring-i18n-support/src/main/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSource.java
@@ -11,6 +11,8 @@ import org.slf4j.LoggerFactory;
 import java.text.MessageFormat;
 import java.util.Locale;
 
+import static org.springframework.util.StringUtils.hasText;
+
 /**
  * MessageSource that resolves the messages from a configurable DAO Object without any cache. This is the simplest implementation of
  * AbstractDaoMessageSource without any caching. This implementation causes a lot of load on the DAO! If you do not have real time update requirements
@@ -34,6 +36,13 @@ public class NoCacheDaoMessageSource extends AbstractDaoMessageSource {
 		try {
 			String messageForLocale = this.getMessageForLocale(code, locale);
 			if (messageForLocale != null) {
+
+				// Escape ticks even if no placeholders are present.
+				// Method getMessageForLocale does already escape ticks if placeholders exist.
+				if (hasText(messageForLocale) && messageForLocale.contains("'") && !REGEX_PLACEHOLDER.matcher(messageForLocale).find()) {
+					messageForLocale = messageForLocale.replaceAll("'", "''");
+				}
+
 				return this.createMessageFormat(messageForLocale, locale);
 			}
 		} catch (Exception ex) {

--- a/spring-i18n-support/src/test/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSourceTest.java
+++ b/spring-i18n-support/src/test/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSourceTest.java
@@ -1,0 +1,108 @@
+package com.namics.oss.spring.support.i18n;
+
+import com.namics.oss.spring.support.i18n.dao.MessageSourceDao;
+import com.namics.oss.spring.support.i18n.dao.jpa.model.MessageResource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * NoCacheDaoMessageSourceTest.
+ *
+ * @author crfischer, Namics AG
+ * @since 08.12.2017 14:52
+ */
+public class NoCacheDaoMessageSourceTest {
+
+    private NoCacheDaoMessageSource candidate = new NoCacheDaoMessageSource();
+    private MessageSourceDao messageSourceDaoMock = mock(MessageSourceDao.class);
+
+    private String code = "message.source.1";
+    private String lang = "fr";
+
+    @Before
+    public void init() {
+        candidate.setMessageSourceDao(messageSourceDaoMock);
+    }
+
+    @Test
+    public void citeNotEscapedSinceNoArgsNoPlaceholder() {
+
+        String code = "message.source.1";
+        String lang = "fr";
+        String message = "'text' --> not escaped by default since no placeholder";
+        String messageExpected = "'text' --> not escaped by default since no placeholder";
+
+        when(messageSourceDaoMock.findByCodeAndLang(code, lang))
+                .thenReturn(Arrays.asList(
+                        new MessageResource().code(code)
+                                .lang(lang)
+                                .message(message)));
+
+
+        String resolvedMessage = candidate.getMessage(code,null, new Locale(lang));
+
+        assertEquals(messageExpected, resolvedMessage);
+    }
+
+    @Test
+    public void citeEscapedSinceWithArgsWithPlaceholder() {
+
+        String message = "'text' {0} --> escaped by default due to placeholder";
+        String messageExpected = "'text' Arg1Value --> escaped by default due to placeholder";
+
+        when(messageSourceDaoMock.findByCodeAndLang(code, lang))
+                .thenReturn(Arrays.asList(
+                        new MessageResource().code(code)
+                                .lang(lang)
+                                .message(message)));
+
+
+
+        String resolvedMessage = candidate.getMessage(code,new Object[]{"Arg1Value"}, new Locale(lang));
+
+        assertEquals(messageExpected, resolvedMessage);
+    }
+
+    @Test
+    public void citeNotEscapedSinceWithArgsNoPlaceholder() {
+
+        String message = "'text' --> not escaped by default since no placeholder present";
+        String messageExpected = "'text' --> not escaped by default since no placeholder present";
+
+        when(messageSourceDaoMock.findByCodeAndLang(code, lang))
+                .thenReturn(Arrays.asList(
+                        new MessageResource().code(code)
+                                .lang(lang)
+                                .message(message)));
+
+
+        String resolvedMessage = candidate.getMessage(code,new Object[]{"Arg1Value"}, new Locale(lang));
+
+        assertEquals(messageExpected, resolvedMessage);
+    }
+
+    @Test
+    public void citeEscapedSinceNoArgsWithPlaceholder() {
+
+        String message = "'text' {0} --> escaped by default since placeholder present";
+        String messageExpected = "''text'' {0} --> escaped by default since placeholder present";
+
+        when(messageSourceDaoMock.findByCodeAndLang(code, lang))
+                .thenReturn(Arrays.asList(
+                        new MessageResource().code(code)
+                                .lang(lang)
+                                .message(message)));
+
+
+        String resolvedMessage = candidate.getMessage(code,null, new Locale(lang));
+
+        assertEquals(messageExpected, resolvedMessage);
+    }
+}

--- a/spring-i18n-support/src/test/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSourceTest.java
+++ b/spring-i18n-support/src/test/java/com/namics/oss/spring/support/i18n/NoCacheDaoMessageSourceTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +29,11 @@ public class NoCacheDaoMessageSourceTest {
 
     @Before
     public void init() {
+
+        // assert default
+        assertFalse(candidate.isAlwaysEscapeTicks());
+
+        candidate.setAlwaysEscapeTicks(true);
         candidate.setMessageSourceDao(messageSourceDaoMock);
     }
 
@@ -75,6 +81,26 @@ public class NoCacheDaoMessageSourceTest {
 
         String message = "'text' --> not escaped by default since no placeholder present";
         String messageExpected = "'text' --> not escaped by default since no placeholder present";
+
+        when(messageSourceDaoMock.findByCodeAndLang(code, lang))
+                .thenReturn(Arrays.asList(
+                        new MessageResource().code(code)
+                                .lang(lang)
+                                .message(message)));
+
+
+        String resolvedMessage = candidate.getMessage(code,new Object[]{"Arg1Value"}, new Locale(lang));
+
+        assertEquals(messageExpected, resolvedMessage);
+    }
+
+    @Test
+    public void citeNotEscapedSinceWithArgsNoPlaceholderDoNotEscapeTicks() {
+
+        candidate.setAlwaysEscapeTicks(false);
+
+        String message = "'text' --> not escaped by default since no placeholder present";
+        String messageExpected = "text --> not escaped by default since no placeholder present";
 
         when(messageSourceDaoMock.findByCodeAndLang(code, lang))
                 .thenReturn(Arrays.asList(


### PR DESCRIPTION
- Added property to control whether ticks should be escaped when message with arguments (but no corresponding placeholders) is resolved in NoCacheDaoMessageResource